### PR TITLE
Replaced Featured Carousel spacing method from TransformY to MarginTop

### DIFF
--- a/react-client/src/components/carousels/FeaturedCarousel.tsx
+++ b/react-client/src/components/carousels/FeaturedCarousel.tsx
@@ -36,7 +36,7 @@ export default observer(function FeaturedCarousel({ data }: Props) {
                     {data.map((anime) => (
                         <Box key={anime.id} bgImage={[anime.coverImage.large!, anime.bannerImage!]} position='relative' height={['60vh', null, '70vh']} backgroundSize='cover' backgroundPosition='center' display='flex' alignItems='center' justifyContent='center' overflow='visible'>
                             <Box position='absolute' top={0} bottom={0} left={0} right={0} background='rgba(0, 0, 0, 0.3)' bgGradient='linear(to-b, transparent, rgba(0, 0, 0, 1))' display='flex' alignItems={['end', 'center']} justifyContent={['center', null, 'start']} padding={{ base: '1rem', md: '8rem' }}>
-                                <Stack transform={[null, 'translateY(30%)']} alignItems={['center', null, 'start']} width='100%' maxWidth={['100%', null, '40vw']} gap={4} >
+                                <Stack marginTop={[null, '10%']} alignItems={['center', null, 'start']} width='100%' maxWidth={['100%', null, '40vw']} gap={4} >
                                     <Heading size={['lg', null, 'xl']} textAlign={['center', null, 'left']}>{anime.title.english ?? anime.title.romaji}</Heading>
                                     {anime.genres && <Text color='text.subtle'>{anime.genres.join(', ')}</Text>}
                                     <Text display={{ base: 'none', md: '-webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 4' }} overflow='hidden' textOverflow='ellipsis'>{stripHtml(anime.description!)}</Text>


### PR DESCRIPTION
Fixed issue where text in the featured carousel would get cut off on big screens due to using Transform Translate. Switched to giving the carousel items a marginTop to offset them slightly below center.