### PR TITLE
Fixed issue where hoverable dots container spanned the entire width o…

### DIFF
--- a/react-client/src/components/carousels/FeaturedCarousel.tsx
+++ b/react-client/src/components/carousels/FeaturedCarousel.tsx
@@ -91,10 +91,12 @@ export default observer(function FeaturedCarousel({ data }: Props) {
 
             <CustomFeaturedPrevArrow onClick={onPrevButtonClick} />
             <CustomFeaturedNextArrow onClick={onNextButtonClick} />
-            <Box id="featured-dots" display="flex" justifyContent="center" onMouseEnter={onHover} onMouseLeave={onUnhover}>
-                {scrollSnaps.map((_, index) => (
-                    <CustomDot key={index} onClick={() => onDotButtonClick(index)} isActive={selectedIndex === index ? true : false} isHovered={isHovered} timeRemaining={progress} />
-                ))}
+            <Box w="100%" display="flex" justifyContent="center">
+                <Box id="featured-dots" w="fit-content" display="flex" justifyContent="center" onMouseEnter={onHover} onMouseLeave={onUnhover}>
+                    {scrollSnaps.map((_, index) => (
+                        <CustomDot key={index} onClick={() => onDotButtonClick(index)} isActive={selectedIndex === index ? true : false} isHovered={isHovered} timeRemaining={progress} />
+                    ))}
+                </Box>
             </Box>
         </Box>
     )


### PR DESCRIPTION
…f the carousel.

Fixed issue where the container of the dots that triggered isHovered spanned the entire width of the carousel making the isHovered effect trigger if you had your mouse outside of the dots area. Added a parent container and made the child container have a width of fit-content.